### PR TITLE
builtin (datetime): Added missed fields and docs enhanced

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,5 +205,10 @@ dist
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,node,lua
 
+### JetBrains IDEs ###
+.idea
+
+### Other ###
+
 build
 .rocks

--- a/src/builtin/datetime/DateTimeTable.d.ts
+++ b/src/builtin/datetime/DateTimeTable.d.ts
@@ -1,42 +1,33 @@
 
-/** Table of [time units](https://www.tarantool.io/en/doc/latest/reference/reference_lua/datetime/#datetime-new-args) */
+/** See result of [datetime_object:totable](https://www.tarantool.io/en/doc/latest/reference/reference_lua/datetime/#lua-function.datetime_object.totable) */
 export interface DateTimeTable {
   /**
-   * Fractional part of the last second.
-   * You can specify either nanoseconds (nsec), or microseconds (usec), or milliseconds (msec). Specifying two of these units simultaneously or all three ones lead to an error.
+   * Nanoseconds.
    */
   nsec: number;
 
-  /** See nsec */
-  usec: number;
-
-  /** See nsec */
-  msec: number;
-
   /**
-   * Seconds. Value range: 0 - 60.
-   * A leap second is supported, see a section [leap second](https://www.tarantool.io/en/doc/latest/reference/reference_lua/datetime/#leap-second).
+   * Seconds.
    */
   sec: number;
 
   /**
-   * Minutes. Value range: 0 - 59.
+   * Minutes.
    */
   min: number;
 
   /**
-   * Hours. Value range: 0 - 23.
+   * Hours.
    */
   hour: number;
 
   /**
-   * Day number. Value range: 1 - 31.
-   * The special value -1 generates the last day of a particular month (see [example below](https://www.tarantool.io/en/doc/latest/reference/reference_lua/datetime/#datetime-new-example)).
+   * Day number.
    */
   day: number;
 
   /**
-   * Month number. Value range: 1 - 12.
+   * Month number.
    */
   month: number;
 
@@ -56,6 +47,11 @@ export interface DateTimeTable {
   yday: number;
 
   /**
+   * Timestamp, in seconds.
+   */
+  timestamp: number;
+
+  /**
    * Is the DST(Daylight saving time) applicable for the date.
    */
   isdst: boolean;
@@ -64,14 +60,6 @@ export interface DateTimeTable {
    * Time zone offset from UTC.
    */
   tzoffset: number;
-
-  /**
-   * Timestamp, in seconds.
-   * Similar to the Unix timestamp, but can have a fractional part that is converted in nanoseconds in the resulting datetime object.
-   * If the fractional part for the last second is set via the nsec, usec, or msec units, the timestamp value should be integer otherwise an error occurs.
-   * The timestamp is not allowed if you already set time and/or date via specific units, namely, sec, min, hour, day, month, and year.
-   */
-  timestamp: number;
 
   /**
    * A time zone name according to the Time Zone Database. See the [Time zones](https://www.tarantool.io/en/doc/latest/reference/reference_lua/datetime/#timezone) section.

--- a/src/builtin/datetime/DateTimeTable.d.ts
+++ b/src/builtin/datetime/DateTimeTable.d.ts
@@ -1,31 +1,42 @@
+
+/** Table of [time units](https://www.tarantool.io/en/doc/latest/reference/reference_lua/datetime/#datetime-new-args) */
 export interface DateTimeTable {
   /**
-   * Nanosecods.
+   * Fractional part of the last second.
+   * You can specify either nanoseconds (nsec), or microseconds (usec), or milliseconds (msec). Specifying two of these units simultaneously or all three ones lead to an error.
    */
   nsec: number;
 
+  /** See nsec */
+  usec: number;
+
+  /** See nsec */
+  msec: number;
+
   /**
-   * Seconds
+   * Seconds. Value range: 0 - 60.
+   * A leap second is supported, see a section [leap second](https://www.tarantool.io/en/doc/latest/reference/reference_lua/datetime/#leap-second).
    */
   sec: number;
 
   /**
-   * Minutes.
+   * Minutes. Value range: 0 - 59.
    */
   min: number;
 
   /**
-   * Hours.
+   * Hours. Value range: 0 - 23.
    */
   hour: number;
 
   /**
-   * Day number.
+   * Day number. Value range: 1 - 31.
+   * The special value -1 generates the last day of a particular month (see [example below](https://www.tarantool.io/en/doc/latest/reference/reference_lua/datetime/#datetime-new-example)).
    */
   day: number;
 
   /**
-   * Month number;
+   * Month number. Value range: 1 - 12.
    */
   month: number;
 
@@ -53,4 +64,17 @@ export interface DateTimeTable {
    * Time zone offset from UTC.
    */
   tzoffset: number;
+
+  /**
+   * Timestamp, in seconds.
+   * Similar to the Unix timestamp, but can have a fractional part that is converted in nanoseconds in the resulting datetime object.
+   * If the fractional part for the last second is set via the nsec, usec, or msec units, the timestamp value should be integer otherwise an error occurs.
+   * The timestamp is not allowed if you already set time and/or date via specific units, namely, sec, min, hour, day, month, and year.
+   */
+  timestamp: number;
+
+  /**
+   * A time zone name according to the Time Zone Database. See the [Time zones](https://www.tarantool.io/en/doc/latest/reference/reference_lua/datetime/#timezone) section.
+   */
+  tz: string;
 }

--- a/src/builtin/datetime/DateTimeUnits.d.ts
+++ b/src/builtin/datetime/DateTimeUnits.d.ts
@@ -1,3 +1,5 @@
+
+/** [Possible input time units for datetime.new()](https://www.tarantool.io/en/doc/latest/reference/reference_lua/datetime/#datetime-new-args) */
 export interface DateTimeUnits {
   /**
    * Fractional part of the last second.
@@ -25,6 +27,7 @@ export interface DateTimeUnits {
 
   /**
    * Seconds. Value range: 0 - 60.
+   * A leap second is supported, see a section [leap second](https://www.tarantool.io/en/doc/latest/reference/reference_lua/datetime/#leap-second).
    * @default 0
    */
   sec?: number;
@@ -42,7 +45,8 @@ export interface DateTimeUnits {
   hour?: number;
 
   /**
-   * Day number. Value range: 1 - 31. The special value `-1` generates the last day of a particular month.
+   * Day number. Value range: 1 - 31.
+   * The special value `-1` generates the last day of a particular month (see [example below](https://www.tarantool.io/en/doc/latest/reference/reference_lua/datetime/#datetime-new-example)).
    * @default 1
    */
   day?: number;
@@ -71,12 +75,14 @@ export interface DateTimeUnits {
 
   /**
    * Time zone offset from UTC, in minutes. If both `tzoffset` and `tz` are specified, `tz` has the preference and the `tzoffset` value is ignored.
+   * See a section [timezone](https://www.tarantool.io/en/doc/latest/reference/reference_lua/datetime/#timezone).
    * @default 0
    */
   tzoffset?: number;
 
   /**
    * Time zone name according to the tz database.
+   * See the [Time zones](https://www.tarantool.io/en/doc/latest/reference/reference_lua/datetime/#timezone) section.
    */
   tz?: string;
 }


### PR DESCRIPTION
Added missed fields in `DateTimeTable`: `timestamp` and `tz`

Full field description copied from official documentation.
Documentation links looks good at least in JetBrains IDEs (e.g. WebStorm).
<img width="404" alt="Снимок экрана 2024-12-27 в 08 35 23" src="https://github.com/user-attachments/assets/95f29ffc-9427-4e99-b573-a2674f2a4de4" />
<img width="326" alt="Снимок экрана 2024-12-27 в 08 35 08" src="https://github.com/user-attachments/assets/37d70f13-fb64-4725-a447-3f34191696a5" />
